### PR TITLE
fix: fix redirection issue and user info display

### DIFF
--- a/src/app/dashboard/onboarding-details.tsx
+++ b/src/app/dashboard/onboarding-details.tsx
@@ -1,7 +1,8 @@
-import { auth } from "@clerk/nextjs";
+import { auth, clerkClient } from "@clerk/nextjs/server";
 
 export function OnboardingDetails() {
-  const { sessionClaims } = auth()
+  const { userId } = auth()
+  const user = clerkClient.users.getUser(userId);
 
   return (
     <div className="bg-white shadow overflow-hidden sm:rounded-lg" style={{ boxShadow: `0px 20px 24px -4px rgba(16, 24, 40, 0.08)` }}>
@@ -13,19 +14,19 @@ export function OnboardingDetails() {
           <div className="px-8 py-2">
             <dt className="text-sm font-semibold">Onboarding Completed?</dt>
             <dd className="mt-1 text-sm text-gray-600 sm:mt-0 sm:col-span-2 flex gap-2">
-              {sessionClaims?.metadata.onboardingComplete ? "Yes" : "No"}
+              {user?.publicMetadata?.onboardingComplete ? "Yes" : "No"}
             </dd>
           </div>
           <div className="px-8 py-2">
             <dt className="text-sm font-semibold">Application Name</dt>
             <dd className="mt-1 text-sm text-gray-600 sm:mt-0 sm:col-span-2 flex gap-2">
-              {sessionClaims?.metadata.applicationName}
+              {user?.publicMetadata?.applicationName}
             </dd>
           </div>
           <div className="px-8 py-2">
             <dt className="text-sm font-semibold">Application Type</dt>
             <dd className="mt-1 text-sm text-gray-600 sm:mt-0 sm:col-span-2 flex gap-2">
-              {sessionClaims?.metadata.applicationType}
+              {user?.publicMetadata?.applicationType}
             </dd>
           </div>
         </dl>

--- a/src/app/dashboard/onboarding-details.tsx
+++ b/src/app/dashboard/onboarding-details.tsx
@@ -1,8 +1,7 @@
-import { auth, clerkClient } from "@clerk/nextjs/server";
+import { currentUser } from '@clerk/nextjs/server';
 
-export function OnboardingDetails() {
-  const { userId } = auth()
-  const user = clerkClient.users.getUser(userId);
+export async function OnboardingDetails() {
+  const user = await currentUser();
 
   return (
     <div className="bg-white shadow overflow-hidden sm:rounded-lg" style={{ boxShadow: `0px 20px 24px -4px rgba(16, 24, 40, 0.08)` }}>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,16 +1,16 @@
-import { auth } from "@clerk/nextjs";
+import { currentUser } from '@clerk/nextjs/server';
 import { SessionDetails, UserDetails } from "./details";
 import { OnboardingDetails } from "./onboarding-details";
 
-export default function Dashboard() {
-  const { userId, sessionClaims } = auth()
+export default async function Dashboard() {
+  const user = await currentUser();
 
   return (
     <div className="px-8 py-12 sm:py-16 md:px-20">
-      {userId && (
+      {user && (
         <>
           <h1 className="text-3xl font-semibold text-black">
-            👋 Hi, {sessionClaims?.firstName || `Stranger`}
+            👋 Hi, {user?.firstName || `Stranger`}
 
           </h1>
           <div className="grid gap-4 mt-8 lg:grid-cols-3">

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,7 +10,7 @@ export default authMiddleware({
   publicRoutes: ["/"],
   afterAuth: async (auth, req: NextRequest) => {
     const { userId } = auth
-    const user = await clerkClient.users.getUser(userId);
+    const user = userId && await clerkClient.users.getUser(userId);
 
     // For user visiting /onboarding, don't try and redirect
     if (userId && req.nextUrl.pathname === "/onboarding") {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,7 @@
 import { authMiddleware } from "@clerk/nextjs";
 import { redirectToSignIn } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
+import { clerkClient } from "@clerk/nextjs/server";
 
 // This example protects all routes including api/trpc routes
 // Please edit this to allow other routes to be public as needed.
@@ -8,7 +9,8 @@ import { NextRequest, NextResponse } from "next/server";
 export default authMiddleware({
   publicRoutes: ["/"],
   afterAuth: async (auth, req: NextRequest) => {
-    const { userId, sessionClaims } = auth
+    const { userId } = auth
+    const user = await clerkClient.users.getUser(userId);
 
     // For user visiting /onboarding, don't try and redirect
     if (userId && req.nextUrl.pathname === "/onboarding") {
@@ -20,7 +22,7 @@ export default authMiddleware({
 
     // Catch users who doesn't have `onboardingComplete: true` in PublicMetata
     // Redirect them to the /onboading out to complete onboarding
-    if (userId && !sessionClaims?.metadata?.onboardingComplete) {
+    if (userId && !user.publicMetadata.onboardingComplete) {
       const onboardingUrl = new URL("/onboarding", req.url);
       return NextResponse.redirect(onboardingUrl)
     }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -22,7 +22,7 @@ export default authMiddleware({
 
     // Catch users who doesn't have `onboardingComplete: true` in PublicMetata
     // Redirect them to the /onboading out to complete onboarding
-    if (userId && !user.publicMetadata.onboardingComplete) {
+    if (userId && !user?.publicMetadata?.onboardingComplete) {
       const onboardingUrl = new URL("/onboarding", req.url);
       return NextResponse.redirect(onboardingUrl)
     }


### PR DESCRIPTION
Currently, the app is using `sessionClaims` to check on the `publicMetadata`, which is wrong (as `sessionClaims` is just jwt payload and `publicMetadata` belongs to user object), this PR is fixing to use clerk `User` so that both redirection and user info display would work.

<img width="1703" alt="image" src="https://github.com/clerk/clerk-nextjs-onboarding-sample-app/assets/1580956/2e7c5b0d-41df-4f78-a821-8349931d215f">

cc @royanger @jshek-clerk 